### PR TITLE
fix: do not use uninitialized memory

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -1,7 +1,11 @@
 #include "app.h"
 
 void add_new_color_from_pick(UNUSED GtkWidget *self, struct CallbackData *ui) {
-	ui->color_data = color_pick();
+	/* do not add a new color if color_pick fails */
+	if (color_pick(&ui->color_data) == -1) {
+		return;
+	}
+
 	add_new_color(ui);
 }
 

--- a/src/color/color.h
+++ b/src/color/color.h
@@ -7,7 +7,7 @@ struct Color {
 enum ColorChannel { COLOR_CHANNEL_RED, COLOR_CHANNEL_GREEN, COLOR_CHANNEL_BLUE };
 
 // Misc
-struct Color color_pick ();
+int color_pick (struct Color *color);
 struct Color color_apply (struct Color *c, int amount);
 char *create_color_range_gradient(struct Color c, enum ColorChannel, char*buffer);
 struct Color color_from_hex(char *hex);


### PR DESCRIPTION
if the user cancelled the pick action with right click, an uninitialized
color with garbage will still be added to the list, so here is a simple
fix that changes the `color_pick` function to also return a status code.

the status code can be:

* -1 : color not picked
*  0 : color picked (can be used)